### PR TITLE
fix: add missing so_branch_name input

### DIFF
--- a/actions/DAST/cryptolyzer/action.yaml
+++ b/actions/DAST/cryptolyzer/action.yaml
@@ -27,6 +27,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/DAST/drheader/action.yaml
+++ b/actions/DAST/drheader/action.yaml
@@ -30,6 +30,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/DAST/zap/action.yaml
+++ b/actions/DAST/zap/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/SAST/bandit/action.yaml
+++ b/actions/SAST/bandit/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/SAST/checkov/action.yaml
+++ b/actions/SAST/checkov/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/SAST/eslint/action.yaml
+++ b/actions/SAST/eslint/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/SAST/kics/action.yaml
+++ b/actions/SAST/kics/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/SAST/semgrep/action.yaml
+++ b/actions/SAST/semgrep/action.yaml
@@ -35,6 +35,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/SAST/tfsec/action.yaml
+++ b/actions/SAST/tfsec/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/SAST/trivy_config/action.yaml
+++ b/actions/SAST/trivy_config/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/SCA/grype_image/action.yaml
+++ b/actions/SCA/grype_image/action.yaml
@@ -27,6 +27,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/SCA/trivy_filesystem/action.yaml
+++ b/actions/SCA/trivy_filesystem/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/SCA/trivy_image/action.yaml
+++ b/actions/SCA/trivy_image/action.yaml
@@ -27,6 +27,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/actions/importer/action.yaml
+++ b/actions/importer/action.yaml
@@ -16,6 +16,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_file_name:
     description: 'Name of the file to import.'
     required: true

--- a/actions/secrets/gitleaks/action.yaml
+++ b/actions/secrets/gitleaks/action.yaml
@@ -27,6 +27,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/DAST/cryptolyzer/action.yaml
+++ b/dev/actions/DAST/cryptolyzer/action.yaml
@@ -27,6 +27,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/DAST/drheader/action.yaml
+++ b/dev/actions/DAST/drheader/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/DAST/zap/action.yaml
+++ b/dev/actions/DAST/zap/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/SAST/bandit/action.yaml
+++ b/dev/actions/SAST/bandit/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/SAST/checkov/action.yaml
+++ b/dev/actions/SAST/checkov/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/SAST/eslint/action.yaml
+++ b/dev/actions/SAST/eslint/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/SAST/kics/action.yaml
+++ b/dev/actions/SAST/kics/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/SAST/semgrep/action.yaml
+++ b/dev/actions/SAST/semgrep/action.yaml
@@ -35,6 +35,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/SAST/tfsec/action.yaml
+++ b/dev/actions/SAST/tfsec/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/SAST/trivy_config/action.yaml
+++ b/dev/actions/SAST/trivy_config/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/SCA/grype_image/action.yaml
+++ b/dev/actions/SCA/grype_image/action.yaml
@@ -27,6 +27,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/SCA/trivy_filesystem/action.yaml
+++ b/dev/actions/SCA/trivy_filesystem/action.yaml
@@ -31,6 +31,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/SCA/trivy_image/action.yaml
+++ b/dev/actions/SCA/trivy_image/action.yaml
@@ -27,6 +27,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false

--- a/dev/actions/importer/action.yaml
+++ b/dev/actions/importer/action.yaml
@@ -16,6 +16,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_file_name:
     description: 'Name of the file to import.'
     required: true

--- a/dev/actions/secrets/gitleaks/action.yaml
+++ b/dev/actions/secrets/gitleaks/action.yaml
@@ -27,6 +27,9 @@ inputs:
   so_product_name:
     description: 'Name of the product which observations are imported. The product has to exist before starting the import.'
     required: true
+  so_branch_name:
+    description: 'Name of the product branch which observations are imported. If the branch does not exist yet, it is automatically created.'
+    required: false
   so_origin_service:
     description: 'Service name to be set for all imported observations.'
     required: false


### PR DESCRIPTION
Github Actions was complaining about `so_branch_name` not being a valid input to the actions. It still worked though. This PR defines the input and thus removes the warning.

We successfully tested it, example run: https://github.com/stackabletech/stack_scanner/actions/runs/8109686447/job/22165427579