### PR TITLE
fix: SARIF must be in capital letters to match SecObserve's parser name

### DIFF
--- a/docker/entrypoints/entrypoint_bandit.sh
+++ b/docker/entrypoints/entrypoint_bandit.sh
@@ -12,7 +12,7 @@ else
 fi
 
 export SO_FILE_NAME="${REPORT_NAME}"
-export SO_PARSER_NAME="Sarif"
+export SO_PARSER_NAME="SARIF"
 
 echo ----------------------------------------
 echo Bandit

--- a/docker/entrypoints/entrypoint_checkov.sh
+++ b/docker/entrypoints/entrypoint_checkov.sh
@@ -12,7 +12,7 @@ else
 fi
 
 export SO_FILE_NAME="${REPORT_NAME}"
-export SO_PARSER_NAME="Sarif"
+export SO_PARSER_NAME="SARIF"
 
 echo ----------------------------------------
 echo Checkov

--- a/docker/entrypoints/entrypoint_eslint.sh
+++ b/docker/entrypoints/entrypoint_eslint.sh
@@ -12,7 +12,7 @@ else
 fi
 
 export SO_FILE_NAME="${REPORT_NAME}"
-export SO_PARSER_NAME="Sarif"
+export SO_PARSER_NAME="SARIF"
 
 echo ----------------------------------------
 echo ESLint

--- a/docker/entrypoints/entrypoint_gitleaks.sh
+++ b/docker/entrypoints/entrypoint_gitleaks.sh
@@ -12,7 +12,7 @@ else
 fi
 
 export SO_FILE_NAME="${REPORT_NAME}"
-export SO_PARSER_NAME="Sarif"
+export SO_PARSER_NAME="SARIF"
 
 echo ----------------------------------------
 echo GitLeaks

--- a/docker/entrypoints/entrypoint_kics.sh
+++ b/docker/entrypoints/entrypoint_kics.sh
@@ -16,7 +16,7 @@ if [[ -z "${OUTPUT_PATH}" ]]; then
 fi
 
 export SO_FILE_NAME="${OUTPUT_PATH}"/"${REPORT_NAME}"
-export SO_PARSER_NAME="Sarif"
+export SO_PARSER_NAME="SARIF"
 
 echo ----------------------------------------
 echo KICS

--- a/docker/entrypoints/entrypoint_semgrep.sh
+++ b/docker/entrypoints/entrypoint_semgrep.sh
@@ -12,7 +12,7 @@ else
 fi
 
 export SO_FILE_NAME="${REPORT_NAME}"
-export SO_PARSER_NAME="Sarif"
+export SO_PARSER_NAME="SARIF"
 
 echo ----------------------------------------
 echo Semgrep

--- a/docker/entrypoints/entrypoint_tfsec.sh
+++ b/docker/entrypoints/entrypoint_tfsec.sh
@@ -12,7 +12,7 @@ else
 fi
 
 export SO_FILE_NAME="${REPORT_NAME}"
-export SO_PARSER_NAME="Sarif"
+export SO_PARSER_NAME="SARIF"
 
 echo ----------------------------------------
 echo tfsec


### PR DESCRIPTION
fixes #220 