### PR TITLE
fix: GitLab templates invoke entrypoints to ensure errors are propagated.

### DIFF
--- a/templates/check_security_gate.yml
+++ b/templates/check_security_gate.yml
@@ -5,4 +5,4 @@
   variables:
     GIT_STRATEGY: none
   script:
-    - check_security_gate.sh
+    - /entrypoints/entrypoint_check_security_gate.sh

--- a/templates/importer.yml
+++ b/templates/importer.yml
@@ -5,5 +5,5 @@
   variables:
     GIT_STRATEGY: none
   script:
-    - file_upload_observations.sh
+    - /entrypoints/entrypoint_importer.sh
   allow_failure: true

--- a/templates/upload_observations.yml
+++ b/templates/upload_observations.yml
@@ -6,5 +6,5 @@
     GIT_STRATEGY: none
     SO_SUPPRESS_LICENSES: true
   script:
-    - file_upload_observations.sh
+    - /entrypoints/entrypoint_importer.sh
   allow_failure: true

--- a/templates/upload_sbom.yml
+++ b/templates/upload_sbom.yml
@@ -5,5 +5,5 @@
   variables:
     GIT_STRATEGY: none
   script:
-    - file_upload_sbom.sh
+    - /entrypoints/entrypoint_upload_sbom.sh
   allow_failure: true

--- a/templates/vulnerability_scanner.yml
+++ b/templates/vulnerability_scanner.yml
@@ -2,7 +2,7 @@
   image:
     name: docker.io/maibornwolff/secobserve-scanners:2025_09
   script:
-    - scan_vulnerabilities.sh
+    - /entrypoints/entrypoint_vulnerability_scanner.sh
   interruptible: true
   allow_failure: true
   artifacts:


### PR DESCRIPTION
I've noticed the check_security_gate stopped failing after the update to 2025_09.  It would appear the changes in #308 and #303 are what triggered this behavior change.

Most of the GitLab templates (all in secrets, DAST, SAST and SCA) invoke the entrypoint scripts which use `set -e` to make the scripts fail on non-zero exit status.

However, this is not the case for `check_security_gate`, `importer`, `upload_observations`, `upload_sbom` or `vulnerability_scanner`.

I've confirmed this will work by switching to the entrypoint by overriding the `script` element when invoking the `check_security_gate` template.